### PR TITLE
Implemented methods to compare threshold to usage

### DIFF
--- a/src/components/css/styles.css
+++ b/src/components/css/styles.css
@@ -400,6 +400,17 @@ ul {
   margin-top: 50px;
 }
 
+.threshold {
+  background: #57a3c6c0;
+  font-weight: 300;
+  font-size: 17px;
+  color: white;
+  text-align: center;
+  line-height: 30px;
+  /* border-radius: 10px 10px 0 0; */
+  margin: 0;
+}
+
 .chart-title {
   background: #052e41c0;
   font-weight: 700;

--- a/src/components/helper/commands.tsx
+++ b/src/components/helper/commands.tsx
@@ -10,10 +10,7 @@ import {
 import store from '../../renderer/store';
 import { makeArrayOfObjects } from './processLogHelper';
 import * as child_process from 'child_process';
-import * as os from 'os-utils';
-// import * as util from 'util';
-import utilPromisify from 'util.promisify'
-import { ConstructionOutlined, LegendToggleOutlined } from '@mui/icons-material';
+
 /**
  * Grabs all active containers on app-start up
  *
@@ -604,7 +601,7 @@ export const dockerComposeDown = (fileLocation, ymlFileName) => {
  */
 
 export const writeToDb = () => {
-  const interval = 30000;
+  const interval = 150000;
   setInterval(() => {
     const state = store.getState();
 

--- a/src/components/tabs/Metrics.js
+++ b/src/components/tabs/Metrics.js
@@ -11,10 +11,23 @@ import LineChartDisplay from '../display/LineChartDisplay';
  * @param {*} props
  */
 const Metrics = (props) => {
+  const fullRunningList = props.runningList;
   const result = convertToMetricsArr(props.runningList);
   const cpuData = (100 - result[0]).toFixed(2);
   const memoryData = (100 - result[1]).toFixed(2);
+  const cpuThreshold = props.threshold[0];
+  const memThreshold = props.threshold[1];
 
+  let cpuFails = 0;
+  let memFails = 0;
+
+  for (const each of fullRunningList) {
+    const cpu = parseFloat(each['CPUPerc'].replace(/([%])+/g, ''));
+    const memory = parseFloat(each['MemPerc'].replace(/([%])+/g, ''));
+    if (cpu >= cpuThreshold) cpuFails++;
+    if(memory >= memThreshold) memFails++;
+  }
+  
   const cpu = {
     labels: [`Available: ${cpuData}%`, `Usage: ${result[0].toFixed(2)}%`],
     datasets: [
@@ -145,6 +158,26 @@ const Metrics = (props) => {
             <h1 className='chart-title'>BLOCK IO:</h1>
             <p className='chart-number'>
               {Math.floor(result[3][0])}B / {Math.floor(result[3][1])}B
+            </p>
+          </div>
+          <div className='chart-container'>
+            <h1 className='chart-title'># of Running Containers:</h1>
+            <p className='chart-number'>
+              {fullRunningList.length}
+            </p>
+          </div>
+          <div className='chart-container'>
+            <h1 className='chart-title'>CPU Fail Counts:</h1>
+            <h4 className='threshold'>Threshold: {cpuThreshold}%</h4>
+            <p className='chart-number'>
+              {cpuFails}
+            </p>
+          </div>
+          <div className='chart-container'>
+            <h1 className='chart-title'>Memory Fail Counts:</h1>
+            <h4 className='threshold'>Threshold: {memThreshold}%</h4>
+            <p className='chart-number'>
+              {memFails}
             </p>
           </div>
         </div>

--- a/src/components/views/SysAdmin.tsx
+++ b/src/components/views/SysAdmin.tsx
@@ -66,6 +66,7 @@ const SysAdmin = () => {
   const runningList = useSelector((state: StateType) => state.containersList.runningList);
   const stoppedList = useSelector((state: StateType) => state.containersList.stoppedList);
   const imagesList = useSelector((state: StateType) => state.images.imagesList);
+  const { mem_threshold, cpu_threshold } = useSelector((state: StateType) => state.session);
   // const networkList = useSelector((state: StateType) => state.networkList.networkList);
   const userInfo = useSelector((state: StateType) => state.session); //* Feature only for SysAdmin
   const arrayOfVolumeNames = useSelector(
@@ -285,7 +286,7 @@ const SysAdmin = () => {
           />}
         />
         <Route path='/metrics' element={
-          <Metrics key={1} runningList={runningList}
+          <Metrics key={1} runningList={runningList} threshold={[cpu_threshold, mem_threshold]}
           />}
         />
         <Route path='/users' element={<UserList />} />


### PR DESCRIPTION
This pull request will merge new methods to compare CpuPercentage and MemPercentage to the set thresholds on the user account. This data is pulled from state, where it is then used to populate a mem and cpu fails metric, which is rendered into new components in the Metrics tab. 

Co-authored-by: Nathan Cho <nathanycho@users.noreply.github.com>